### PR TITLE
Updated Recruit Cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of cogs for use by the Solarmark gaming community and it's eve onli
 ### Current cogs
 Cog |  Purpose
 --- | ---
-`thread.py` | Add a right-click context menu and slash command for recruiters to create a private recruitment thread, automaically bringing in the recruit and all recruiters. Also handles thread archival settings via slash command.
+`thread.py` | Add a right-click context menu and slash command for recruiters to create a private recruitment thread, automatically bringing in the recruit and all recruiters. Also handles thread archival settings via slash command.
 
 ## How to Install
 *(Assumes a docker environment and does not use correct standards for installing. Really you/me should publish this to pypi.)*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of cogs for use by the Solarmark gaming community and it's eve onli
 ### Current cogs
 Cog |  Purpose
 --- | ---
-`thread.py` | Add a context menu for recruiters to right click on a user and create a private recruitment thread, auotmaically bringing in the recruit and all recruiters.
+`thread.py` | Add a right-click context menu and slash command for recruiters to create a private recruitment thread, automaically bringing in the recruit and all recruiters. Also handles thread archival settings via slash command.
 
 ## How to Install
 *(Assumes a docker environment and does not use correct standards for installing. Really you/me should publish this to pypi.)*
@@ -25,7 +25,10 @@ Cog |  Purpose
 ## Settings
 Setting | Default | Description
 --- | --- | ---
+`SOLARMARK_GUILDID` | ` ` | ID of the Discord server in which the bot will be operating.
 `SOLARMARK_RECRUIT_CHANID` | ` ` | ID of the channel you want the threads created in.
-`SOLARMARK_CORP_ROLEID` | ` ` | List of roles you don't want recruited (such as those already in corp)
-`SOLARMARK_RECRUIT_MSG` | ` ` | The Message that is posted to the thread on creation. (Also handles who is invited to the thread through the use of @mentions)
-`SOLARMARK_RECRUITER_ROLEID` | ` ` | Role(s) you want to be able to use the recruit action.
+`SOLARMARK_TARGET_ROLEID` | ` ` | List of Role IDs, one of which must be present on the target to be valid for recruitment (must have visibility of SOLARMARK_RECRUIT_CHANID text channel).
+`SOLARMARK_CORP_ROLEID` | ` ` | List of Role IDs that you don't want able to be recruited (such as those already in corp).
+`SOLARMARK_RECRUITER_ROLEID` | ` ` | List of Role IDs that you want to be able to use the recruit action.
+`SOLARMARK_LEADERSHIP_USERIDS` | ` ` | List of User IDs to include in the initial thread message (and therefore be automatically pulled into each thread).
+`SOLARMARK_RECRUIT_MSG_1` | ` ` | The message that is posted to the thread on creation (also handles who is invited to the thread through the use of @mentions).

--- a/solarmark_aauthcogs/cogs/recruit.py
+++ b/solarmark_aauthcogs/cogs/recruit.py
@@ -4,24 +4,44 @@ Recruitment Thread cog for aa-discordbot - https://github.com/pvyParts/alliancea
 Creates a private thread for recruiters and recruits in your discord to manage recruitment of new members.
 """
 # Cog Stuff
-import logging
-logger = logging.getLogger(__name__)
 import discord
+import re
 from discord.ext import commands
 
 # AA Contexts
 from django.conf import settings
 
 # Validation Checks - These values must be defined in server settings
-
+if not hasattr(settings, "SOLARMARK_GUILDID"):
+    raise ValueError("SOLARMARK_GUILDID is not defined.")
 if not hasattr(settings, "SOLARMARK_RECRUIT_CHANID"):
-    raise ValueError("Recruitment base channel is not defined")
-if not hasattr(settings, "SOLARMARK_RECRUIT_MSG"):
-    raise ValueError("Recruitment message is not defined")
+    raise ValueError("SOLARMARK_RECRUIT_CHANID is not defined.")
+if not hasattr(settings, "SOLARMARK_TARGET_ROLEID"):
+    raise ValueError("SOLARMARK_TARGET_ROLEID is not defined.")
 if not hasattr(settings, "SOLARMARK_CORP_ROLEID"):
-    raise ValueError("Corporation role ID is not defined")
+    raise ValueError("SOLARMARK_CORP_ROLEID is not defined.")
 if not hasattr(settings, "SOLARMARK_RECRUITER_ROLEID"):
-	raise ValueError("Recruitment role ID is not defined")
+	raise ValueError("SOLARMARK_RECRUITER_ROLEID is not defined.")
+if not hasattr(settings, "SOLARMARK_LEADERSHIP_USERIDS"):
+	raise ValueError("SOLARMARK_LEADERSHIP_USERIDS is not defined.")
+if not hasattr(settings, "SOLARMARK_RECRUIT_MSG_1"):
+    raise ValueError("SOLARMARK_RECRUIT_MSG_1 is not defined.")
+
+# Returns the count of how many SOLARMARK_RECRUIT_MSG_# settings variables are available, assuming SOLARMARK_RECRUIT_MSG_1 will always exist
+async def msgcount():
+	i = 0
+	while (hasattr(settings, "SOLARMARK_RECRUIT_MSG_" + str((i + 1)))):
+		i += 1
+	return i
+	
+# Returns whether the reaction clicked on by a user in recruitment is valid
+async def valid_reaction(self, reaction, user):
+	if reaction.message.channel.name == "RCT-" + user.name:
+		if reaction.emoji == '\N{White Heavy Check Mark}':
+			async for user in reaction.users():
+				if user.id == self.bot.user.id:
+					return True
+	return False
 
 class Recruit(commands.Cog):
 	"""
@@ -30,13 +50,29 @@ class Recruit(commands.Cog):
 	
 	def __init__(self, bot):
 		self.bot = bot
+	
+	# Listener for added reactions to see whether additional recruitment messages should be sent
+	@discord.Cog.listener()
+	async def on_reaction_add(self, reaction, user):
+		if await valid_reaction(self, reaction, user):
+			msg = re.sub("<.*?>", "<@{}>", reaction.message.content)
+			msgnum = await msgcount()
+			for x in range(1, msgnum):
+				if msg == eval("settings.SOLARMARK_RECRUIT_MSG_{}".format(x)):
+					await reaction.message.clear_reactions()
+					messageinfo = await self.bot.get_channel(reaction.message.channel.id).send(eval("settings.SOLARMARK_RECRUIT_MSG_{}".format(x + 1)))
+					if x < (msgnum - 1):
+						await messageinfo.add_reaction('\N{White Heavy Check Mark}')
+					return
 
+	# Checks to see whether a thread exists for the given user and returns the thread ID if so
 	async def thread_exist(self, member):
 		for thread in self.bot.get_channel(settings.SOLARMARK_RECRUIT_CHANID).threads:
 			if thread.name == "RCT-" + member.name:
-				return True
-		return False
+				return thread.id
+		return 0
 
+	# Checks whether the user who invoked the command is authorized to do so given their roles
 	async def caller_authorized(self, ctx):
 		for userrole in ctx.author.roles:
 			for id in settings.SOLARMARK_RECRUITER_ROLEID:
@@ -44,39 +80,104 @@ class Recruit(commands.Cog):
 					return True
 		return False
 
-	async def target_not_in_corp(self, member):
+	# Checks to see if target user is already in Solarmark
+	async def target_in_corp(self, member):
 		for userrole in member.roles:
 			for id in settings.SOLARMARK_CORP_ROLEID:
 				if userrole.id == id:
-					return False
-		return True
+					return True
+		return False
 
+	# Checks to see if the target has access to the EVE Online text channel
+	async def target_has_role(self, member):
+		for userrole in member.roles:
+			for id in settings.SOLARMARK_TARGET_ROLEID:
+				if userrole.id == id:
+					return True
+		return False
+
+	# Runs through the various check methods to determine whether a given recruitment invocation is valid
 	async def can_recruit(self, ctx, member):
+		threadid = await self.thread_exist(member)
 		if not await self.caller_authorized(ctx):
 			await ctx.respond("You do not have permission to use this command.", ephemeral = True)
 			return False
-		if not await self.target_not_in_corp(member):
+		elif await self.target_in_corp(member):
 			await ctx.respond("That user is already in the corporation.", ephemeral = True)
 			return False
-		if await self.thread_exist(member):
-			await ctx.respond("That user already has an active recruitment thread.", ephemeral = True)
+		elif threadid > 0:
+			await ctx.respond("That user already has an active recruitment thread: <#" + str(threadid) + ">", ephemeral = True)
+			return False
+		elif not await self.target_has_role(member):
+			await ctx.respond("That user must have the EVE Online role present on their account.", ephemeral = True)
 			return False
 		return True
 
-	@discord.user_command(name="Recruit for EVE")
+	# Sets up right-click user command for EVE recruitment
+	@discord.user_command(name = "Recruit for EVE", guild_ids = [settings.SOLARMARK_GUILDID])
+	async def recruit_user(self, ctx, member: discord.Member):
+		if await self.can_recruit(ctx, member):
+			channel = self.bot.get_channel(settings.SOLARMARK_RECRUIT_CHANID)
+			threadname = "RCT-" + member.name
+			messagetext = settings.SOLARMARK_RECRUIT_MSG_1.format(
+				member.id,
+				*settings.SOLARMARK_LEADERSHIP_USERIDS
+			)
+			threadinfo = await channel.create_thread(name = threadname, auto_archive_duration = 10080, type = discord.ChannelType.public_thread)
+			messageinfo = await self.bot.get_channel(threadinfo.id).send(messagetext)
+			if await msgcount() > 1:
+				await messageinfo.add_reaction('\N{White Heavy Check Mark}')
+			if ctx.author.id in settings.SOLARMARK_LEADERSHIP_USERIDS:
+				await ctx.respond("Recruitment thread created: " + threadinfo.mention, ephemeral = True)
+			else:
+				await ctx.respond("Recruitment thread created!", ephemeral = True)
+
+	# Sets up /recruit command for EVE recruitment
+	@discord.command(description = "Recruit for EVE. Use an @ mention to choose the user.", guild_ids = [settings.SOLARMARK_GUILDID])
 	async def recruit(self, ctx, member: discord.Member):
 		if await self.can_recruit(ctx, member):
 			channel = self.bot.get_channel(settings.SOLARMARK_RECRUIT_CHANID)
 			threadname = "RCT-" + member.name
-			messagetext = settings.SOLARMARK_RECRUIT_MSG.format(
+			messagetext = settings.SOLARMARK_RECRUIT_MSG_1.format(
 				member.id,
-				97032350247972864,
-				97049182073786368,
-				72091276689801216
+				*settings.SOLARMARK_LEADERSHIP_USERIDS
 			)
-			threadinfo = await channel.create_thread(name=threadname, auto_archive_duration=10080, type=discord.ChannelType.private_thread)
-			await self.bot.get_channel(threadinfo.id).send(messagetext)
-			await ctx.respond("Recruitment thread created!", ephemeral = True)
+			threadinfo = await channel.create_thread(name = threadname, auto_archive_duration = 10080, type = discord.ChannelType.public_thread)
+			messageinfo = await self.bot.get_channel(threadinfo.id).send(messagetext)
+			if await msgcount() > 1:
+				await messageinfo.add_reaction('\N{White Heavy Check Mark}')
+			if ctx.author.id in settings.SOLARMARK_LEADERSHIP_USERIDS:
+				await ctx.respond("Recruitment thread created: " + threadinfo.mention, ephemeral = True)
+			else:
+				await ctx.respond("Recruitment thread created!", ephemeral = True)
+
+	# Allows users to have the bot update the auto-archive setting for a thread
+	@discord.command(description = "Update thread expiration. Accepted values are 'now', '1h', '1d', '3d', '7d'.", guild_ids = [settings.SOLARMARK_GUILDID])
+	async def archive(self, ctx, when: discord.Option(str)):
+		when = when.lower()
+		if not await self.caller_authorized(ctx):
+			await ctx.respond("You do not have permission to use this command.", ephemeral = True)
+		elif not (ctx.channel.type == discord.ChannelType.public_thread or ctx.channel.type == discord.ChannelType.private_thread):
+			await ctx.respond("This command can only be used inside threads.", ephemeral = True)
+		elif not re.match("now|1h|1d|3d|7d", when):
+			await ctx.respond("That is not a valid option for 'when', please try again.", ephemeral = True)
+		else:
+			match when:
+				case "now":
+					await ctx.respond("Thread archived!", ephemeral = True)
+					await ctx.channel.edit(archived = True)
+				case "1h":
+					await ctx.channel.edit(auto_archive_duration = 60)
+					await ctx.respond("Thread auto-archive set to 1 hour!", ephemeral = True)
+				case "1d":
+					await ctx.channel.edit(auto_archive_duration = 1440)
+					await ctx.respond("Thread auto-archive set to 1 day!", ephemeral = True)
+				case "3d":
+					await ctx.channel.edit(auto_archive_duration = 4320)
+					await ctx.respond("Thread auto-archive set to 3 days!", ephemeral = True)
+				case "7d":
+					await ctx.channel.edit(auto_archive_duration = 10080)
+					await ctx.respond("Thread auto-archive set to 1 week!", ephemeral = True)
 
 # Set the bot up
 def setup(bot):


### PR DESCRIPTION
Changelog:
1. Updated thread messaging to be a more dynamic flow, breaking the various steps out into individual messages that the recruited user moves through at their leisure by using reactions to affirm their status on each step.
2. Added /recruit command to invoke the same functionality as the existing application command so that leadership can create recruitment threads on mobile devices.
3. Added /archive command to allow Solarmark leadership to change the archival duration on existing threads.
4. Updated ephemeral message that gets shown to leadership upon thread creation to include a link to the thread if the leadership user can see the thread. The message was not updated in the case that a leadership member CANNOT see the thread such is the case for leadership members that aren't part of the recruiting team.
5. Added handling for an edge case where the target of recruitment hasn't yet gained access to the SOLARMARK_RECRUIT_CHANID channel.
6. Removed hardcoded user IDs, instead pulling them from settings dynamically.